### PR TITLE
install libpulse for audio support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,7 @@ RUN LC_ALL="C.UTF-8" add-pkg \
       libxkbcommon0 \
       libxrandr2 \
       libxrender1 \
+      libpulse-dev \
       libzstd1
 
 # some manual additions, mostly from  v3.47.1


### PR DESCRIPTION
Add libpulse-dev package to Dockerfile, this is needed for PulseAudio support in the container which allows user to hear audio from the application running in the container via the web browser client. The additional package add 120MB (820->940) of data into the extracted docker image. Close #4 