### PR TITLE
Update to the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # See https://github.com/jlesage/docker-baseimage-gui
 
-ARG app_version="3.62.0"
+ARG app_version="3.63.0"
 # Bump if publishing a new image with the same app_version, reset to 1 with new app versions 
 ARG image_revision="1"
 # BUILDPLATFORM and TARGETPLATFORM are defined when using BuildKit (i.e. docker buildx)


### PR DESCRIPTION
This pull request updates the `app_version` in the `Dockerfile` from **3.62.0** to **3.63.0**. This change will ensure that the docker image is built with the latest version of the LosslessCut application.